### PR TITLE
Feature/#40 devise basic auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,12 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,6 +2,7 @@
   
   <% if user_signed_in? %>
     <div class="text-lg">現在、ログインしています</div>
+    <div class="text-lg">名前: <%= current_user.name %></div>
     <div class="text-lg">メールアドレス: <%= current_user.email %></div>
     <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-secondary" %>
   <% else %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,8 +4,13 @@
   <%= render "users/shared/error_messages", resource: resource %>
 
   <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autocomplete: "email" %>
   </div>
 
   <div class="field">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations',
+    sessions: 'users/sessions',
+    confirmations: 'users/confirmations',
+    passwords: 'users/passwords',
+    unlocks: 'users/unlocks'
+  }
   root "posts#index"
 end


### PR DESCRIPTION
## 概要
### 参考資料
#### deviseの公式README
https://github.com/heartcombo/devise/blob/main/README.md#getting-started

#### deviseで扱うmoduleについての公式ドキュメント
https://www.rubydoc.info/gems/devise/Devise/Models

#### Rails: Deviseを徹底理解する（1）基礎編（翻訳）
https://techracho.bpsinc.jp/hachi8833/2023_09_01/133452

### 実装手順
#### Dockerコンテナを起動
```zsh
docker compose up
```

#### gem `devise` をGemfileに追加してバンドル
```zsh
docker compose exec web bundle add devise
```

#### deviseをインストール
```zsh
docker compose exec web rails generate devise:install
```

#### Userモデルを作成
```zsh
docker compose exec web rails generate devise user
```

- ルーティングファイルに自動的に`devise_for :users`が追加される。
  `config/routes.rb`
  ```ruby
  Rails.application.routes.draw do
    devise_for :users
    root "posts#index"
  end
  ```

  **`devise_for :users`によって追加されたルーティング一覧**
  - **sessions（ログイン・ログアウト）**
  ![Image](https://github.com/user-attachments/assets/ea3effe3-388a-4b73-95b5-9199687d0239)
  
  - **registrations（新規登録）**
  ![Image](https://github.com/user-attachments/assets/dd4b4349-58fe-40a1-92f1-ac8929edf35b)
  
  - **passwords（パスワードリセット）**
  ![Image](https://github.com/user-attachments/assets/bc530da6-c104-44bb-97c3-0793d6711570)

####  生成されたマイグレーションファイルにname(string型)を追加
`db/migrate/20250701074658_devise_create_users.rb`
```ruby
# frozen_string_literal: true

class DeviseCreateUsers < ActiveRecord::Migration[7.2]
  def change
    create_table :users do |t|
      ## Database authenticatable
      t.string :email,              null: false, default: ""
      t.string :encrypted_password, null: false, default: ""
      t.string :name,               null: false, default: ""
.
.
.
```

#### マイグレーション実行
```zsh
docker compose exec web rails db:migrate
```

#### カスタムViewの生成
```zsh
docker compose exec web rails generate devise:views users
```
**⚠️この段階ではまだブラウザ上に表示されるのはDeviseのデフォルトViewになります。この後、カスタムControllerを生成し、ルーティング設定することで、カスタムViewがブラウザ上で表示されるようになります。**
- 上記コマンドを実行した際に生成されたView一覧(`app/views/users以下`)
  <img width="375" alt="Image" src="https://github.com/user-attachments/assets/1765917d-3ddf-447c-9ad7-55e0d91b59aa" />
  
  **ユーザー認証に関わる主要なViewファイル**
  
  **ログイン画面(`http://localhost:3000/users/sign_in`)**
  Viewファイルの相対パス: `app/views/users/sessions/new.html.erb`
  ![Image](https://github.com/user-attachments/assets/5c2771ce-472b-414f-8dd5-eb533dcd1f61)
  
  **新規登録画面(`http://localhost:3000/users/sign_up`)**
  Viewファイルの相対パス: `app/views/users/registrations/new.html.erb`
  ![Image](https://github.com/user-attachments/assets/02918466-0a9d-4344-a03d-202cbb31294f)
  
  **パスワードリセット画面(`http://localhost:3000/users/password/new`)**
  Viewファイルの相対パス: `app/views/users/passwords/new.html.erb`
  ![Image](https://github.com/user-attachments/assets/10ce88a8-112c-4b4c-8e00-08bc38ccec59)
  
  **エラーメッセージパーシャル**
  Viewファイルの相対パス: `app/views/users/shared/_error_messages.html.erb`
  
  **リンクパーシャル**
  Viewファイルの相対パス: `app/views/users/shared/_links.html.erb`

#### カスタムControllerの生成
```zsh
docker compose exec web rails generate devise:controller users
```
- 上記コマンドを実行した際に生成されたController一覧(`app/controllers/users以下`)
  <img width="424" alt="Image" src="https://github.com/user-attachments/assets/b53243ae-2743-4d0a-b213-ad88653fa62b" />

#### ルーティングの変更
 `config/routes.rb`
```ruby
Rails.application.routes.draw do
  devise_for :users, controllers: {
    registrations: 'users/registrations',
    sessions: 'users/sessions',
    confirmations: 'users/confirmations',
    passwords: 'users/passwords',
    unlocks: 'users/unlocks'
  }
  root "posts#index"
end
```
- ここまで行うと、カスタムViewがブラウザ上に表示されます。

#### Strong Parametersにnameフィールドを追加する
Deviseでカスタムフィールド（今回の場合はname）を追加した場合、Strong Parametersの設定が必要です。
これが設定されていないと、フォームから送信されたnameの値が無視されて、name=""の状態でユーザーが作成されてしまいます。
Deviseのアクションsign_in, sign_up, account_updateではデフォルトでnameフィールドが許可されていないので、明示的に`devise_parameter_sanitizer.permit`で許可する必要があります。

参照: https://github.com/heartcombo/devise/blob/main/README.md#strong-parameters
> There are just three actions in Devise that allow any set of parameters to be passed down to the model, therefore requiring sanitization. Their names and default permitted parameters are:
> - sign_in (Devise::SessionsController#create) - Permits only the authentication keys (like email)
> - sign_up (Devise::RegistrationsController#create) - Permits authentication keys plus password and password_confirmation
> - account_update (Devise::RegistrationsController#update) - Permits authentication keys plus password, password_confirmation and current_password

具体的には以下のようにコントローラーを修正します。
`app/controllers/application_controller.rb`
```ruby
class ApplicationController < ActionController::Base
  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
  allow_browser versions: :modern

  before_action :configure_permitted_parameters, if: :devise_controller?

  protected

  def configure_permitted_parameters
    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
  end
end
```

Strong Parametersの設定を変更したことにより、ユーザー作成の際にnameフィールドも許可されていることがわかります。
<img width="1380" alt="Image" src="https://github.com/user-attachments/assets/fe1ea4c1-55a2-49aa-bac7-eb68927fa7da" />